### PR TITLE
Creates back element on ref object sec creation

### DIFF
--- a/patches/insert_back_where_created_ref_object_secs
+++ b/patches/insert_back_where_created_ref_object_secs
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+########################
+# Patch for missing back element for refObjectSec elements created in BaseTerm
+#
+# Arguments:
+# $1: postgresql url
+########################
+
+set -o xtrace
+
+declare -r POSTGRES_URL="$1"
+INSERT_BACK_QUERY=$(cat <<-EOF
+  INSERT INTO termbase_text.back (termbase_uuid)
+  SELECT DISTINCT(termbase_uuid) FROM termbase_text.ref_object_sec WHERE termbase_uuid NOT IN (
+    SELECT DISTINCT(termbase_UUID) FROM termbase_text.back 
+  );
+EOF
+)
+readonly INSERT_BACK_QUERY
+
+psql \
+-d "${POSTGRES_URL}" \
+-c "${INSERT_BACK_QUERY}"

--- a/src/services/RefService.ts
+++ b/src/services/RefService.ts
@@ -39,11 +39,43 @@ class RefService {
     return personId.substring(3);
   }
 
+  private async retrieveBack(
+    termbaseUUID: UUID,
+    dbClient: types.DBClient
+  ) {
+    const back = this.helpers.pluckOne(
+      await dbClient<dbTypes.Back>(tables.backTable.fullTableName)
+        .where({
+          termbase_uuid: termbaseUUID,
+        })
+        .select("*")
+    );
+
+    if (back !== null) {
+      return back
+    }
+
+    const newBack = this.helpers.pluckOne(
+      await dbClient<dbTypes.Back>(tables.backTable.fullTableName)
+        .insert({
+          termbase_uuid: termbaseUUID,
+        })
+        .returning<dbTypes.Back[]>("*")
+    ) as dbTypes.Back
+
+    return newBack
+  }
+
   private async retrieveRefObjectSec(
     termbaseUUID: UUID,
     type: string,
     dbClient: types.DBClient
   ) {
+    await this.retrieveBack(
+      termbaseUUID,
+      dbClient
+    )
+
     const refObjectSec = this.helpers.pluckOne(
       await dbClient<dbTypes.RefObjectSec>(tables.refObjectSecTable.fullTableName)
         .where({


### PR DESCRIPTION
This patch creates a back element if it doesn't exist when ref object sec elements are created.

Linked issue: https://github.com/BYU-TRG-Team/baseterm/issues/16