### PR TITLE
Run e2e and integration tests serially

### DIFF
--- a/bin/configs/e2e-tests.yaml
+++ b/bin/configs/e2e-tests.yaml
@@ -60,6 +60,7 @@ services:
       "--",
       "jest",
       "--coverage",
+      "--runInBand",
       "--testMatch=**/tests/e2e-tests/**/*.test.ts"
     ]
     

--- a/bin/configs/integration-tests.yaml
+++ b/bin/configs/integration-tests.yaml
@@ -61,7 +61,6 @@ services:
       "jest",
       "--coverage",
       "--runInBand",
-      "--detectOpenHandles",
       "--testMatch=**/tests/integration-tests/**/*.test.ts"
     ]
     


### PR DESCRIPTION
When running e2e or integration tests in parallel using the baseterm-api docker image, Jest will throw warnings indicating that some worker processes did not exit upon completion of tests. 

Running these tests serially invokes no warning. These tests also share no resources. The warning is likely resulting from CPU/memory issues specific to the docker container that only occur when the tests are run in parallel.

Since there is not a great need to run these tests in parallel at this time, running them serially should be good for now.